### PR TITLE
feat: add ARMv6 support for Raspberry Pi Zero W

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -44,6 +44,7 @@ jobs:
           path: |
             server/bin/sentryusb-linux-arm64
             server/bin/sentryusb-linux-armv7
+            server/bin/sentryusb-linux-armv6
           retention-days: 30
 
       - name: Attach to release
@@ -54,4 +55,5 @@ jobs:
           gh release upload "${{ github.event.release.tag_name }}" \
             server/bin/sentryusb-linux-arm64 \
             server/bin/sentryusb-linux-armv7 \
+            server/bin/sentryusb-linux-armv6 \
             --clobber

--- a/install.sh
+++ b/install.sh
@@ -260,7 +260,7 @@ ARCH=$(uname -m)
 case "$ARCH" in
     aarch64)  BINARY_SUFFIX="linux-arm64"; GO_ARCH="arm64" ;;
     armv7l)   BINARY_SUFFIX="linux-armv7"; GO_ARCH="armv6l" ;;
-    armv6l)   BINARY_SUFFIX="linux-armv7"; GO_ARCH="armv6l" ;;
+    armv6l)   BINARY_SUFFIX="linux-armv6"; GO_ARCH="armv6l" ;;
     x86_64)   BINARY_SUFFIX="linux-amd64"; GO_ARCH="amd64" ;;
     *)        error_exit "Unsupported architecture: $ARCH" ;;
 esac

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-arm64 build-armv7 dev clean copy-static
+.PHONY: build build-arm64 build-armv7 build-armv6 dev clean copy-static
 
 # Build for current platform
 build: copy-static
@@ -12,8 +12,12 @@ build-arm64: copy-static
 build-armv7: copy-static
 	GOOS=linux GOARCH=arm GOARM=7 go build -o bin/sentryusb-linux-armv7 .
 
+# Build for Raspberry Pi Zero W (original, ARMv6)
+build-armv6: copy-static
+	GOOS=linux GOARCH=arm GOARM=6 go build -o bin/sentryusb-linux-armv6 .
+
 # Build all Pi targets
-build-all: build-arm64 build-armv7
+build-all: build-arm64 build-armv7 build-armv6
 
 # Copy built frontend into static/ for embedding
 copy-static:


### PR DESCRIPTION
## Problem

The Raspberry Pi Zero W (original) uses an **ARMv6** CPU (`armv6l`), not ARMv7. Running an ARMv7 binary on ARMv6 hardware causes an immediate crash:

```
Illegal instruction (status=4)
```

The current `install.sh` maps `armv6l` to the `linux-armv7` binary, which means Pi Zero W (v1.x) users cannot use SentryUSB.

## Changes

### `install.sh`
Fixed architecture detection so `armv6l` downloads the correct `linux-armv6` binary instead of `linux-armv7`.

```diff
-    armv6l)   BINARY_SUFFIX="linux-armv7"; GO_ARCH="armv6l" ;;
+    armv6l)   BINARY_SUFFIX="linux-armv6"; GO_ARCH="armv6l" ;;
```

### `server/Makefile`
Added `build-armv6` target with `GOARM=6` and included it in `build-all`:

```makefile
build-armv6: copy-static
	GOOS=linux GOARCH=arm GOARM=6 go build -o bin/sentryusb-linux-armv6 .

build-all: build-arm64 build-armv7 build-armv6
```

### `.github/workflows/build-binaries.yml`
Added `sentryusb-linux-armv6` to both the upload-artifact paths and the release upload step. Since `make build-all` is already called, no additional build steps are needed.

## Testing

Cross-compiled the binary locally:
```
$ GOOS=linux GOARCH=arm GOARM=6 go build -o bin/sentryusb-linux-armv6 .
$ file bin/sentryusb-linux-armv6
bin/sentryusb-linux-armv6: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked...
```

Tested successfully on a Pi Zero W v1.1 (armv6l) — no more SIGILL crashes.