### PR TITLE
Fix/pi4 udc dwc2 detection

### DIFF
--- a/setup/pi/setup-sentryusb
+++ b/setup/pi/setup-sentryusb
@@ -1472,16 +1472,32 @@ then
       reboot
       exit 0
     fi
-  else
-    if ! grep -q 'dtoverlay=dwc2' "$PICONFIG_PATH"
+    else
+    if isPi4
     then
-      echo -e "dtoverlay=dwc2\n" >> "$PICONFIG_PATH"
-      setup_progress "rebooting to apply dwc2 overlay change"
-      reboot
-      exit 0
+      if ! grep -q '^\[pi4\]' "$PICONFIG_PATH"
+      then
+        if grep -q '^\[cm4\]' "$PICONFIG_PATH"
+        then
+          sed -i '/^\[cm4\]/i [pi4]\ndtoverlay=dwc2\n' "$PICONFIG_PATH"
+        else
+          printf '\n[pi4]\ndtoverlay=dwc2\n' >> "$PICONFIG_PATH"
+        fi
+        setup_progress "rebooting to apply dwc2 overlay change (Pi4 gadget mode)"
+        reboot
+        exit 0
+      fi
+    else
+      if ! grep -q 'dtoverlay=dwc2' "$PICONFIG_PATH"
+      then
+        echo -e "dtoverlay=dwc2\n" >> "$PICONFIG_PATH"
+        setup_progress "rebooting to apply dwc2 overlay change"
+        reboot
+        exit 0
+      fi
     fi
   fi
-fi
+
 
 configure_hostname
 

--- a/setup/pi/setup-sentryusb
+++ b/setup/pi/setup-sentryusb
@@ -1465,14 +1465,13 @@ then
   then
     if ! grep -q 'dtoverlay=dwc2,dr_mode=peripheral' "$PICONFIG_PATH"
     then
-      # Remove plain dtoverlay=dwc2 if present (from a prior setup attempt)
       sed -i '/^dtoverlay=dwc2$/d' "$PICONFIG_PATH"
       echo -e "dtoverlay=dwc2,dr_mode=peripheral\n" >> "$PICONFIG_PATH"
       setup_progress "rebooting to apply dwc2 overlay change (peripheral mode for Pi 3)"
       reboot
       exit 0
     fi
-    else
+  else
     if isPi4
     then
       if ! grep -q '^\[pi4\]' "$PICONFIG_PATH"
@@ -1497,7 +1496,7 @@ then
       fi
     fi
   fi
-
+fi
 
 configure_hostname
 


### PR DESCRIPTION
Fixed an issue I encountered setting up SentryUSB on a Pi 4B 1.2. It hung on the dwc driver not being correct.

This fixes the logic to handle Pi 4B dwc2 driver install.