### PR TITLE
Remove unused volume prop from CommunityTab via Cluade

### DIFF
--- a/web/src/pages/LockChime.tsx
+++ b/web/src/pages/LockChime.tsx
@@ -202,7 +202,7 @@ export default function LockChime() {
       {tab === "library" ? (
         <MyLibraryTab volume={volume} />
       ) : (
-        <CommunityTab adminPasscode={adminPasscode} volume={volume} />
+        <CommunityTab adminPasscode={adminPasscode} />
       )}
 
       {/* Passcode modal */}


### PR DESCRIPTION
The volume prop was passed to CommunityTab but never accepted or used, causing TypeScript build errors.