### PR TITLE
Wire up volume control for audio playback

### DIFF
--- a/web/src/pages/LockChime.tsx
+++ b/web/src/pages/LockChime.tsx
@@ -202,7 +202,7 @@ export default function LockChime() {
       {tab === "library" ? (
         <MyLibraryTab volume={volume} />
       ) : (
-        <CommunityTab adminPasscode={adminPasscode} />
+        <CommunityTab adminPasscode={adminPasscode} volume={volume} />
       )}
 
       {/* Passcode modal */}
@@ -407,6 +407,7 @@ function MyLibraryTab({ volume }: { volume: number }) {
     audioRef.current?.pause()
     const url = `${API_BASE}/files/download?path=/mutable/LockChime/${encodeURIComponent(name)}`
     const audio = new Audio(url)
+    audio.volume = volume
     audioRef.current = audio
     audio.onended = () => setPlayingName(null)
     audio.onerror = () => {
@@ -943,7 +944,7 @@ function MyLibraryTab({ volume }: { volume: number }) {
 // Community tab
 // ─────────────────────────────────────────────────────────────
 
-function CommunityTab({ adminPasscode }: { adminPasscode: string | null }) {
+function CommunityTab({ adminPasscode, volume }: { adminPasscode: string | null; volume: number }) {
   const [subTab, setSubTab] = useState<CommunitySubTab>("browse")
 
   return (
@@ -1008,6 +1009,7 @@ function CommunityBrowse({ adminPasscode }: { adminPasscode: string | null }) {
     audioRef.current?.pause()
     const url = `${API_BASE}/lockchime/community/stream/${code}`
     const audio = new Audio(url)
+    audio.volume = volume
     audioRef.current = audio
     audio.onended = () => setPlayingCode(null)
     audio.onerror = () => {


### PR DESCRIPTION
## Summary
- Wire up the existing volume slider to actually control audio playback in both `MyLibraryTab` and `CommunityTab`
- Add `volume` prop to `CommunityTab` and set `audio.volume` before playback in both components
- Fixes CI build error: `'volume' is declared but its value is never read`

PR made by Jeff, not Scott.