### PR TITLE
Add fallback time server options for synchronization

### DIFF
--- a/run/archiveloop
+++ b/run/archiveloop
@@ -1034,7 +1034,8 @@ function set_time () {
   local -r clocktime_start=$(date +%s.%N)
   for _ in {1..5}
   do
-    if sntp -S time.google.com || ntpdig -S time.google.com
+    if sntp -S time.google.com || ntpdig -S time.google.com || sntp -S 129.6.15.28 || ntpdig -S 129.6.15.28
+    # Fall back to NIST time server if DNS resolution fails (DNS over TLS & Cert is invalid because of wrong time)
     then
       local -r uptime_end=$(awk '{print $1}' /proc/uptime)
       local -r clocktime_end=$(date +%s.%N)


### PR DESCRIPTION
I had a problem with DNS over TLS failing because the initial time on the pi during bootup caused the certificate to be invalid. Time currently is set with a DNS resolution, so I added a fallback to a NIST timeserver with a known static IP. (time-a-g.nist.gov, 129.6.15.28)