### PR TITLE
fix: send_mobile_push ignores SENTRY_NOTIFICATION_URL

### DIFF
--- a/run/send-push-message
+++ b/run/send-push-message
@@ -157,7 +157,7 @@ function send_mobile_push () {
     -H "Content-Type: application/json" \
     -H "X-Device-Secret: $MOBILE_PUSH_SECRET" \
     -d "$payload" \
-    "https://notifications.sentry-six.com/send") || {
+    "${SENTRY_NOTIFICATION_URL:-https://notifications.sentry-six.com}/send") || {
     log "ERROR: Mobile App Notification — failed to connect to notification server (exit code $?)"
     return 1
   }

--- a/server/api/apiconfig.go
+++ b/server/api/apiconfig.go
@@ -1,18 +1,37 @@
 package api
 
-import "os"
+import (
+	"os"
+
+	"github.com/Scottmg1/Sentry-USB/server/config"
+)
 
 // Backend service base URLs.
-// Override via environment variables for staging/local development.
+// Override via environment variables or sentryusb.conf.
 // Defaults to production values.
 var (
-	APIBaseURL          = envOrDefault("SENTRY_API_URL", "https://api.sentry-six.com")
-	NotificationBaseURL = envOrDefault("SENTRY_NOTIFICATION_URL", "https://notifications.sentry-six.com")
+	APIBaseURL          = configOrDefault("SENTRY_API_URL", "https://api.sentry-six.com")
+	NotificationBaseURL = configOrDefault("SENTRY_NOTIFICATION_URL", "https://notifications.sentry-six.com")
 )
 
 func envOrDefault(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
+	}
+	return fallback
+}
+
+// configOrDefault checks the environment variable first, then sentryusb.conf, then defaults.
+// This allows the systemd service to pick up SENTRY_NOTIFICATION_URL (and other backend URLs)
+// from the user's config file without needing EnvironmentFile in the unit.
+func configOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	if active, _, err := config.ParseFile(config.FindConfigPath()); err == nil {
+		if v, ok := active[key]; ok && v != "" {
+			return v
+		}
 	}
 	return fallback
 }


### PR DESCRIPTION
## What's broken

The `send_mobile_push` function in `run/send-push-message` hardcodes `https://notifications.sentry-six.com` as the push relay endpoint. `SENTRY_NOTIFICATION_URL` already exists as a config key — the Go API server reads it correctly via `apiconfig.go` for pairing, device listing, and test notifications. But the shell script ignores it entirely and always calls the original server, making the config key useless for actual notification delivery.

## How env vars reach the script

`archiveloop` sources `envsetup.sh` which loads all keys from `sentryusb.conf` as exported environment variables. `send-push-message` runs as a subprocess and inherits them. Any key set in `sentryusb.conf` — including `SENTRY_NOTIFICATION_URL` — is already available to the script. The fix just uses it.

## The fix

One line — use `${SENTRY_NOTIFICATION_URL:-https://notifications.sentry-six.com}` as the base URL so `send_mobile_push` behaves consistently with the rest of the codebase.

## No breaking changes

If `SENTRY_NOTIFICATION_URL` is not set in `sentryusb.conf`, behavior is identical to before.