### PR TITLE
feat: bundle tesla-control and tesla-keygen in image build

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -99,6 +99,34 @@ fi
 
 [ -f "$BINARY_PATH" ] || error "Binary not found at $BINARY_PATH"
 
+# ── Step 1b: Build tesla-control and tesla-keygen ──
+# tesla-control is the Tesla BLE command-line tool used by awake_start for
+# Keep Awake BLE mode. Tesla does not publish pre-built binaries, so we build
+# from source. Requires Go 1.23+.
+TESLA_CONTROL_PATH=""
+TESLA_KEYGEN_PATH=""
+if command -v go &>/dev/null; then
+    info "Building tesla-control and tesla-keygen from source..."
+    TESLA_VC_DIR="/tmp/sentryusb-vehicle-command"
+    rm -rf "$TESLA_VC_DIR"
+    git clone --depth 1 https://github.com/teslamotors/vehicle-command.git "$TESLA_VC_DIR"
+    (
+        cd "$TESLA_VC_DIR"
+        if [ -n "$GO_ARM" ]; then
+            GOOS=linux GOARCH=$GO_ARCH GOARM=$GO_ARM go build -o tesla-control ./cmd/tesla-control
+            GOOS=linux GOARCH=$GO_ARCH GOARM=$GO_ARM go build -o tesla-keygen ./cmd/tesla-keygen
+        else
+            GOOS=linux GOARCH=$GO_ARCH go build -o tesla-control ./cmd/tesla-control
+            GOOS=linux GOARCH=$GO_ARCH go build -o tesla-keygen ./cmd/tesla-keygen
+        fi
+    )
+    TESLA_CONTROL_PATH="$TESLA_VC_DIR/tesla-control"
+    TESLA_KEYGEN_PATH="$TESLA_VC_DIR/tesla-keygen"
+    ok "tesla-control and tesla-keygen built"
+else
+    info "Go not available — tesla-control will not be bundled (Keep Awake BLE requires it)"
+fi
+
 # ── Step 2: Clone pi-gen ──
 info "Setting up pi-gen..."
 rm -rf "$WORK_DIR"
@@ -119,6 +147,14 @@ cp "$SCRIPT_DIR/pi-gen-sources/$CONFIG_FILE" "$WORK_DIR/config"
 info "Injecting SentryUSB binary into image build..."
 cp "$BINARY_PATH" "$WORK_DIR/stage_sentryusb/00-sentryusb-tweaks/files/sentryusb-binary"
 chmod +x "$WORK_DIR/stage_sentryusb/00-sentryusb-tweaks/files/sentryusb-binary"
+
+if [ -n "$TESLA_CONTROL_PATH" ] && [ -f "$TESLA_CONTROL_PATH" ]; then
+    info "Injecting tesla-control and tesla-keygen..."
+    cp "$TESLA_CONTROL_PATH" "$WORK_DIR/stage_sentryusb/00-sentryusb-tweaks/files/tesla-control"
+    cp "$TESLA_KEYGEN_PATH"  "$WORK_DIR/stage_sentryusb/00-sentryusb-tweaks/files/tesla-keygen"
+    chmod +x "$WORK_DIR/stage_sentryusb/00-sentryusb-tweaks/files/tesla-control"
+    chmod +x "$WORK_DIR/stage_sentryusb/00-sentryusb-tweaks/files/tesla-keygen"
+fi
 
 info "Injecting BLE daemon files..."
 cp "$SCRIPT_DIR/server/ble/sentryusb-ble.py" "$WORK_DIR/stage_sentryusb/00-sentryusb-tweaks/files/sentryusb-ble.py"

--- a/pi-gen-sources/00-sentryusb-tweaks/00-run.sh
+++ b/pi-gen-sources/00-sentryusb-tweaks/00-run.sh
@@ -92,6 +92,20 @@ else
     echo "WARNING: D-Bus policy file not found — BLE may fail on Pi 5"
 fi
 
+# ── Install tesla-control and tesla-keygen (required for Keep Awake BLE mode) ──
+# These are used by awake_start to send commands to the vehicle over BLE.
+# Tesla does not publish pre-built binaries; they are cross-compiled by build-image.sh.
+# Note: pairing still requires the user to run tesla-keygen and add-key-request manually
+# while physically near their vehicle (keycard tap required). The "Unknown key" label on
+# the Tesla's key list is expected — named keys require Tesla Fleet API developer access.
+for _tc_bin in tesla-control tesla-keygen; do
+    if [ -f "files/$_tc_bin" ]; then
+        install -m 755 "files/$_tc_bin" "${ROOTFS_DIR}/root/bin/$_tc_bin"
+    else
+        echo "WARNING: $_tc_bin not found in files/ — Keep Awake BLE mode will not work without it"
+    fi
+done
+
 # ── Install remountfs_rw helper (needed by BLE daemon to save PIN on read-only rootfs) ──
 if [ -f "../../run/remountfs_rw" ]; then
     install -m 755 "../../run/remountfs_rw" "${ROOTFS_DIR}/root/bin/remountfs_rw"

--- a/run/awake_start
+++ b/run/awake_start
@@ -72,8 +72,14 @@ else
   }
 
   # If Tesla BLE is configured, disable the GATT daemon once for the session.
+  # Guard: only if tesla-control is actually installed — without it there is no
+  # reason to stop the GATT daemon, and doing so would break BLE connectivity.
   if [[ -n "${TESLA_BLE_VIN:+x}" ]]; then
-    ble_disable_gatt_daemon
+    if [ -x /root/bin/tesla-control ]; then
+      ble_disable_gatt_daemon
+    else
+      log "Tesla BLE: tesla-control not found at /root/bin/tesla-control — GATT daemon stays up."
+    fi
   fi
 
   # Returns a label like "Archive", "Drive Processing", "Manual (8m left)"


### PR DESCRIPTION
## Problem

`awake_start` already calls `/root/bin/tesla-control` for Keep Awake BLE mode, but the binary was never included in the image. This means:

- Users who set `TESLA_BLE_VIN` get a silently broken feature — the nudge/sentry-mode commands just fail
- Worse: `awake_start` stops the GATT daemon (`sentryusb-ble`) *before* calling `tesla-control`, even when the binary isn't there. With `Restart=always`, an explicit `systemctl stop` prevents auto-restart — so the GATT daemon goes down and stays down, breaking BLE connectivity for companion apps

## Changes

**`build-image.sh`** — cross-compile `tesla-control` and `tesla-keygen` from [teslamotors/vehicle-command](https://github.com/teslamotors/vehicle-command) during image build. Uses the same Go toolchain already present for the sentryusb binary (requires Go 1.23+). If Go is unavailable, a warning is printed and the build continues without them.

**`pi-gen-sources/00-sentryusb-tweaks/00-run.sh`** — install `tesla-control` and `tesla-keygen` to `/root/bin/` following the same pattern as the sentryusb binary.

**`run/awake_start`** — guard `ble_disable_gatt_daemon()` behind a check that `tesla-control` is actually present. Defensive fallback: if the binary is missing for any reason, the GATT daemon stays up and a log message explains why.

## Testing

Tested on Rock Pi 4C+ (aarch64, Debian Trixie):

- Built `tesla-control` and `tesla-keygen` from source
- Generated EC key pair with `tesla-keygen`
- Ran `add-key-request` → keycard tap on center console → Tesla app confirmed key added
- Confirmed working over BLE: `flash-lights`, `lock`, `unlock`, `sentry-mode on`, `body-controller-state`

## Notes

- The paired key shows as **"Unknown key"** on the Tesla keys screen. This is expected — named keys require Tesla Fleet API developer registration. It has no effect on functionality.
- `tesla-keygen` and the `add-key-request` pairing step still require the user to be physically near their vehicle with a keycard. This is a one-time setup, not something the image can automate.