### PR TITLE
fix: prevent deleted wraps from being resurrected by reverse-sync

### DIFF
--- a/run/archiveloop
+++ b/run/archiveloop
@@ -144,6 +144,8 @@ function sync_user_media_to_cam () {
       mkdir -p "$WRAPS_MOUNT/Wraps"
       rsync -a --delete "/mutable/Wraps/" "$WRAPS_MOUNT/Wraps/" >> "$LOG_FILE" 2>&1 \
         || log "Failed to sync Wraps to wraps drive"
+      # Forward-sync propagated deletions to disk; tombstones no longer needed
+      rm -rf /mutable/.wraps_deleted 2>/dev/null || true
       unmount_mount_point "$WRAPS_MOUNT"
       log "Synced Wraps to dedicated wraps drive."
     else
@@ -154,6 +156,8 @@ function sync_user_media_to_cam () {
         mkdir -p "$CAM_MOUNT/Wraps"
         rsync -a --delete "/mutable/Wraps/" "$CAM_MOUNT/Wraps/" >> "$LOG_FILE" 2>&1 \
           || log "Failed to sync Wraps to cam drive"
+        # Forward-sync propagated deletions to disk; tombstones no longer needed
+        rm -rf /mutable/.wraps_deleted 2>/dev/null || true
         unmount_mount_point "$CAM_MOUNT"
       fi
     fi
@@ -170,6 +174,8 @@ function sync_user_media_to_cam () {
         mkdir -p "$CAM_MOUNT/Wraps"
         rsync -a --delete "/mutable/Wraps/" "$CAM_MOUNT/Wraps/" >> "$LOG_FILE" 2>&1 \
           || log "Failed to sync Wraps to cam drive"
+        # Forward-sync propagated deletions to disk; tombstones no longer needed
+        rm -rf /mutable/.wraps_deleted 2>/dev/null || true
       fi
     fi
     if [ -d "/mutable/LicensePlate" ] && [ -n "$(ls -A /mutable/LicensePlate 2>/dev/null)" ]
@@ -206,8 +212,16 @@ function sync_disk_media_to_host () {
       if [ -d "$WRAPS_MOUNT/Wraps" ] && [ -n "$(ls -A "$WRAPS_MOUNT/Wraps" 2>/dev/null)" ]
       then
         mkdir -p /mutable/Wraps
-        rsync -a --ignore-existing "$WRAPS_MOUNT/Wraps/" "/mutable/Wraps/" >> "$LOG_FILE" 2>&1 \
+        # Build exclude list from tombstones to prevent resurrection of deleted wraps
+        _wraps_exclude_file=$(mktemp)
+        if [ -d /mutable/.wraps_deleted ]; then
+          for _tombstone in /mutable/.wraps_deleted/*; do
+            [ -e "$_tombstone" ] && basename "$_tombstone" >> "$_wraps_exclude_file"
+          done
+        fi
+        rsync -a --ignore-existing --exclude-from="$_wraps_exclude_file" "$WRAPS_MOUNT/Wraps/" "/mutable/Wraps/" >> "$LOG_FILE" 2>&1 \
           || log "Failed to reverse-sync Wraps from wraps drive"
+        rm -f "$_wraps_exclude_file"
         log "Reverse-synced Wraps from wraps drive to /mutable/Wraps."
       fi
       unmount_mount_point "$WRAPS_MOUNT"
@@ -223,8 +237,16 @@ function sync_disk_media_to_host () {
       if [ ! -e /backingfiles/wraps_disk.bin ] && [ -d "$CAM_MOUNT/Wraps" ] && [ -n "$(ls -A "$CAM_MOUNT/Wraps" 2>/dev/null)" ]
       then
         mkdir -p /mutable/Wraps
-        rsync -a --ignore-existing "$CAM_MOUNT/Wraps/" "/mutable/Wraps/" >> "$LOG_FILE" 2>&1 \
+        # Build exclude list from tombstones (same as dedicated disk path above)
+        _wraps_exclude_file=$(mktemp)
+        if [ -d /mutable/.wraps_deleted ]; then
+          for _tombstone in /mutable/.wraps_deleted/*; do
+            [ -e "$_tombstone" ] && basename "$_tombstone" >> "$_wraps_exclude_file"
+          done
+        fi
+        rsync -a --ignore-existing --exclude-from="$_wraps_exclude_file" "$CAM_MOUNT/Wraps/" "/mutable/Wraps/" >> "$LOG_FILE" 2>&1 \
           || log "Failed to reverse-sync Wraps from cam drive"
+        rm -f "$_wraps_exclude_file"
         log "Reverse-synced Wraps from cam drive to /mutable/Wraps."
       fi
       if [ -d "$CAM_MOUNT/LicensePlate" ] && [ -n "$(ls -A "$CAM_MOUNT/LicensePlate" 2>/dev/null)" ]

--- a/server/api/files.go
+++ b/server/api/files.go
@@ -295,6 +295,16 @@ func (h *handlers) deleteFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// If the deleted path was under /mutable/Wraps, create a tombstone so
+	// archiveloop's reverse-sync doesn't resurrect it from the wraps disk.
+	if strings.HasPrefix(cleanPath, "/mutable/Wraps/") {
+		tombstoneDir := "/mutable/.wraps_deleted"
+		if err := os.MkdirAll(tombstoneDir, 0755); err == nil {
+			baseName := filepath.Base(cleanPath)
+			_ = os.WriteFile(filepath.Join(tombstoneDir, baseName), nil, 0644)
+		}
+	}
+
 	// If deleted path was under SavedClips or SentryClips, clean up
 	// matching symlinks in snapshot directories so those clips won't
 	// be re-synced on next archive. RecentClips are left untouched.


### PR DESCRIPTION
## Summary

- Wraps deleted via the web UI Files page, API, or SSH are resurrected by archiveloop's reverse-sync on the next cycle
- Adds tombstone-based deletion tracking: a zero-byte marker in `/mutable/.wraps_deleted/` prevents reverse-sync from copying deleted wraps back from the wraps disk
- Forward-sync's existing `--delete` flag propagates the removal to the wraps disk, then tombstones are cleaned up
- Wraps uploaded directly via USB are unaffected — no tombstone exists for them

## Bug details

The archiveloop two-phase sync creates a resurrection cycle:

1. User deletes a wrap from `/mutable/Wraps/` (via Files page, API, or SSH)
2. Wraps disk still has the file
3. Reverse-sync (`rsync --ignore-existing`) copies it back from the wraps disk
4. Forward-sync sees the file again — never removes it from the disk

Currently the web UI Community page has no "remove installed wrap" button, but the Files page can delete wraps. Both paths hit this bug.

## Changes

- `server/api/files.go` — create tombstone after successful delete of a file under `/mutable/Wraps/`
- `run/archiveloop` — reverse-sync uses `--exclude-from` with tombstone list (both dedicated wraps disk and cam disk fallback paths); forward-sync cleans up tombstones after propagating deletions

## Test plan

- [ ] Download a community wrap, verify it appears in `/mutable/Wraps/`
- [ ] Delete it via Files page or `DELETE /api/files?path=/mutable/Wraps/wrap.png`
- [ ] Run archiveloop (or wait for next cycle) — wrap should NOT reappear
- [ ] Upload a wrap via USB directly to the wraps disk — verify it reverse-syncs to `/mutable/Wraps/` normally
- [ ] Delete a wrap, then re-download the same name — verify new file survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)