### PR TITLE
fix: awake_stop preserves keep-awake state across BLE service restarts

### DIFF
--- a/run/awake_stop
+++ b/run/awake_stop
@@ -18,7 +18,25 @@ fi
 BLE_LOCK="/tmp/ble_keep_awake_active"
 
 ble_restore_gatt_daemon() {
-  if [ ! -e "$BLE_LOCK" ]; then
+  # Fast path: lock exists — normal "we disabled it, time to restore" flow.
+  # Fallback: lock is missing but sentryusb-ble is currently inactive.  This
+  # means the lock got wiped mid-session (e.g. sentryusb-ble.service
+  # restarted and its ExecStartPre removed the lock) but we still owe the
+  # GATT daemon a restart.  Without this fallback, archiveloop calls
+  # awake_stop → sees no lock → returns early → GATT stays down until a
+  # full Pi reboot, leaving companion apps unable to reach the Pi over BLE.
+  local have_lock=0
+  if [ -e "$BLE_LOCK" ]; then
+    have_lock=1
+  fi
+
+  local ble_active=1
+  if ! systemctl is-active --quiet sentryusb-ble 2>/dev/null; then
+    ble_active=0
+  fi
+
+  if [ "$have_lock" = "0" ] && [ "$ble_active" = "1" ]; then
+    # No lock and GATT already running — nothing to restore.
     return
   fi
 
@@ -34,10 +52,21 @@ ble_restore_gatt_daemon() {
     fi
   fi
 
+  # Belt-and-suspenders: also look for a nudge loop by command name in case
+  # the pid file is missing (e.g. lost when /tmp was re-created).
+  if pgrep -f "ble_nudge\|keep_awake_nudge" >/dev/null 2>&1; then
+    log "Tesla BLE: Keep-awake nudge process still running — mobile-app Bluetooth stays disabled."
+    return
+  fi
+
   rm -f "$BLE_LOCK"
-  log "Tesla BLE: Keep-awake ended. Restoring mobile-app Bluetooth (GATT daemon)..."
+  if [ "$have_lock" = "0" ]; then
+    log "Tesla BLE: Keep-awake lock was lost but GATT daemon is down — restoring mobile-app Bluetooth..."
+  else
+    log "Tesla BLE: Keep-awake ended. Restoring mobile-app Bluetooth (GATT daemon)..."
+  fi
   systemctl start sentryusb-ble 2>/dev/null || true
-  log "Tesla BLE: Mobile-app Bluetooth restored. iOS app can connect via Bluetooth again."
+  log "Tesla BLE: Mobile-app Bluetooth restored. Companion apps can connect via Bluetooth again."
 }
 
 # Returns a label like "Archive", "Drive Processing", "Manual (8m left)"

--- a/server/ble/sentryusb-ble.service
+++ b/server/ble/sentryusb-ble.service
@@ -8,9 +8,13 @@ ConditionPathExists=/usr/bin/python3
 
 [Service]
 Type=simple
-# Clean up stale keep-awake lock if present — if systemd is starting us,
-# no keep-awake session should be holding the radio.
-ExecStartPre=-/bin/rm -f /tmp/ble_keep_awake_active
+# Clean up stale keep-awake locks only (older than 24 h).  Matches the
+# BLE_LOCK_MAX_AGE check in run/awake_start.  Unconditionally removing
+# the lock here would break mid-session service restarts: if an archive
+# cycle is active, awake_stop's GATT-restore flow depends on the lock
+# being present.  Wiping a fresh lock leaves the GATT daemon down until
+# the next Pi reboot.
+ExecStartPre=-/bin/bash -c 'f=/tmp/ble_keep_awake_active; [ -e "$f" ] && [ $(( $(date +%s) - $(stat -c %Y "$f" 2>/dev/null || echo 0) )) -gt 86400 ] && rm -f "$f"; exit 0'
 ExecStartPre=/usr/sbin/rfkill unblock bluetooth
 ExecStartPre=-/usr/bin/hciconfig hci0 up
 ExecStartPre=/bin/bash -c 'for i in $(seq 1 30); do busctl status org.bluez >/dev/null 2>&1 && break; echo "Waiting for org.bluez... ($i/30)"; sleep 1; done'


### PR DESCRIPTION
## Problem

`/tmp/ble_keep_awake_active` is the lock that tells `awake_stop` *"we disabled `sentryusb-ble` for a keep-awake session, you need to restart it."* Two issues combined to leave the GATT daemon silent until a full Pi reboot:

1. **`sentryusb-ble.service`'s `ExecStartPre` unconditionally removes the lock on every service start.** If the service restarts mid-session (crash, `RuntimeMaxSec` rollover, manual nudge), the lock is wiped despite the keep-awake session still being active.

2. **`awake_stop`'s `ble_restore_gatt_daemon` returns early when the lock is missing**, so archiveloop's post-archive call never restarts `sentryusb-ble`. Companion apps (iOS + Android) can't reach the Pi over BLE until the user reboots.

## Fix

**`server/ble/sentryusb-ble.service`** — guard `ExecStartPre` so it only wipes stale locks (> 24 h), matching the `BLE_LOCK_MAX_AGE` check already in `run/awake_start`. Preserves a fresh lock across mid-session restarts.

```
ExecStartPre=-/bin/bash -c 'f=/tmp/ble_keep_awake_active; [ -e "$f" ] && [ $(( $(date +%s) - $(stat -c %Y "$f" 2>/dev/null || echo 0) )) -gt 86400 ] && rm -f "$f"; exit 0'
```

**`run/awake_stop`** — `ble_restore_gatt_daemon` gains a fallback path:
- If the lock is missing but `sentryusb-ble` is currently inactive, still run the restore flow (we owe it a restart).
- Adds a `pgrep` check for `ble_nudge`/`keep_awake_nudge` so overlap safety still works when the nudge pid file has been lost.

## Compatibility

Backward compatible. Sessions without the lock bug behave exactly as before (fast path: lock exists → existing nudge check → restore). The fallback only kicks in when the original code would have silently exited and left GATT down.

## Testing

Reproduced and fixed live on Rock Pi 4C+ running SentryUSB v3.6.0:
- **Reproduction (without fix):** triggered `sentryusb-ble` service restart during an active archive cycle. GATT daemon stayed down until manual `systemctl restart sentryusb-ble` or a full Pi reboot.
- **With fix applied:** GATT daemon properly restored post-archive; companion app reconnects within ~5 s.
- **No side effects observed:** Tesla-control keep-awake nudges continue uninterrupted during the handoff.