### PR TITLE
fix: sentryusb-ble.py waits for BlueZ adapter to appear before bailing

### DIFF
--- a/server/ble/sentryusb-ble.py
+++ b/server/ble/sentryusb-ble.py
@@ -22,6 +22,7 @@ import os
 import sys
 import signal
 import logging
+import time
 import urllib.request
 import urllib.error
 import threading
@@ -1093,6 +1094,38 @@ def find_adapter(bus):
             return path
     return None
 
+
+def wait_for_adapter(bus, timeout_s=15, poll_interval_s=0.2):
+    """Wait for BlueZ to expose an LE adapter, polling up to `timeout_s`.
+
+    The systemd unit waits for the org.bluez D-Bus name to be claimed before
+    starting this script, but BlueZ exposes the adapter object asynchronously
+    after claiming the bus name. On a slow boot, busy SD card, or service
+    restart (after archiveloop's awake_stop, OOM kill, RuntimeMaxSec, etc.),
+    a single GetManagedObjects() call can race ahead of adapter enumeration
+    and find nothing. The script then exits 1, systemd retries up to
+    StartLimitBurst times, and if all retries hit the race the service stays
+    inactive until reboot.
+
+    First-principle fix: wait for the dependency we actually need (the LE
+    adapter object), not just the bus name. Polling once every 200ms for ~5
+    iterations is effectively free and simpler than D-Bus InterfacesAdded
+    signal subscription (which has its own race when the adapter already
+    exists at subscribe time).
+    """
+    deadline = time.time() + timeout_s
+    last_log = 0.0
+    while time.time() < deadline:
+        path = find_adapter(bus)
+        if path:
+            return path
+        if time.time() - last_log >= 1.0:
+            remaining = int(deadline - time.time())
+            log.info(f'Waiting for BlueZ adapter... ({remaining}s remaining)')
+            last_log = time.time()
+        time.sleep(poll_interval_s)
+    return None
+
 def register_ad_cb():
     log.info('Advertisement registered')
 
@@ -1219,9 +1252,12 @@ def main():
     # Detect which port the Go API server is on (80 production, 8788 dev)
     API_BASE = detect_api_base()
 
-    adapter_path = find_adapter(bus)
+    # Wait up to 15s for BlueZ to expose the LE adapter — see wait_for_adapter()
+    # docstring for race-condition rationale. Single-shot find_adapter() loses
+    # the race on slow boots, busy SD cards, or service restarts after archiveloop.
+    adapter_path = wait_for_adapter(bus, timeout_s=15)
     if not adapter_path:
-        log.error('No Bluetooth LE adapter found')
+        log.error('No Bluetooth LE adapter found after 15s — BlueZ may be misconfigured')
         sys.exit(1)
 
     log.info(f'Using adapter: {adapter_path}')

--- a/server/ble/sentryusb-ble.service
+++ b/server/ble/sentryusb-ble.service
@@ -5,6 +5,14 @@ After=bluetooth.target bluetooth.service dbus.service
 Requires=bluetooth.target dbus.service
 BindsTo=bluetooth.service
 ConditionPathExists=/usr/bin/python3
+# Defense in depth against the BLE adapter boot race: systemd defaults to
+# StartLimitBurst=5 within StartLimitIntervalSec=10s, which can be exhausted
+# if all 5 attempts hit the race within 30 seconds. Bumping to 20 attempts in
+# 120s gives systemd enough budget to recover before giving up. The Python
+# wait_for_adapter() handles 99% of cases on the first attempt; this is
+# insurance for unrelated future failure modes (BlueZ crash, OOM, etc.).
+StartLimitBurst=20
+StartLimitIntervalSec=120
 
 [Service]
 Type=simple


### PR DESCRIPTION
Replaces the one-shot `find_adapter()` call at startup with a bounded poll (15s timeout, 200ms interval). The unit's existing `busctl` wait loop only confirms BlueZ is running — BlueZ exposes `/org/bluez/hci0` asynchronously after claiming its bus name. A single `GetManagedObjects()` can race ahead of adapter enumeration on slow boots, busy SD cards, or service restarts, causing the script to exit 1.

**Reproduced live on Rock Pi 4C+ running SentryUSB v3.6.2 (2026-04-26):**

```
14:30      Pi boot
14:30–14:44 (14 min)  service inactive — StartLimitBurst exhausted at boot
14:44:53   manual `systemctl start sentryusb-ble` resets counter → fails
           again with same race
14:45:00   systemd auto-retry (RestartSec=5)            → succeeds
```

The "Restart=always handles it" assumption only holds when the first 5-attempt burst (default `StartLimitBurst=5` in 10s) succeeds. If the race wins all 5 attempts, systemd gives up and the service stays inactive until next reboot. Was 14 minutes of dead BLE in this reproduction.

Same risk applies to every restart, not just boot:
- After archiveloop's `awake_stop` (PR #43 fixed the loop, not the race)
- After OOM kill or process crash
- After daily `RuntimeMaxSec=86400` forced restart
- During Pi OTA updates that bounce the service

**First-principle fix:** a service that depends on a resource should wait for the resource, not exit when it's missing. `wait_for_adapter()` polls every 200ms for ~5 iterations until BlueZ exposes the adapter. Negligible CPU during the typical sub-second wait window.

**Defense in depth in the unit file:** bump `StartLimitBurst` to 20 within 120s so unrelated future failures (BlueZ crash, OOM, etc.) don't get locked out either. Not load-bearing for the race — Python handles that.

**Why polling instead of D-Bus `InterfacesAdded` signal:** Signal subscription has its own race (if adapter exists at subscribe time you miss the event — still need a fallback poll). Polling once every 200ms for ~5 iterations is effectively free, no concurrency complexity.

**Files touched:**
- `server/ble/sentryusb-ble.py` — new `wait_for_adapter()` helper, replaces the existing one-shot check at startup
- `server/ble/sentryusb-ble.service` — adds `StartLimitBurst=20` and `StartLimitIntervalSec=120`

Verified `v3.8.9-beta.4` does not contain this fix; PR is not duplicating existing work.