### PR TITLE
fix: archive NFS test fails on fresh installs (UniFi UNAS, etc.)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -215,6 +215,13 @@ done
 if ! command -v sntp &> /dev/null && ! command -v ntpdig &> /dev/null; then
     apt-get install -y sntp 2>/dev/null || apt-get install -y ntpsec-ntpdig 2>/dev/null || true
 fi
+# Archive helpers: without these, the setup wizard's NFS/CIFS test mounts
+# fail with cryptic "didn't pass remote address" / missing-helper errors.
+for pkg in nfs-common cifs-utils; do
+    if ! dpkg-query -W --showformat='${db:Status-Status}\n' "$pkg" 2>/dev/null | grep -q '^installed$'; then
+        apt-get install -y "$pkg" 2>/dev/null || warn "Failed to install $pkg"
+    fi
+done
 ok "Prerequisites installed"
 
 # ── Set hostname early so sentryusb.local works before setup wizard ──

--- a/run/nfs_archive/copy-music.sh
+++ b/run/nfs_archive/copy-music.sh
@@ -1,6 +1,96 @@
 #!/bin/bash -eu
 
-ensure_music_file_is_mounted
-/root/bin/copy-music.sh
-trim_free_space "$MUSIC_MOUNT"
-unmount_music_file
+SRC="/mnt/musicarchive"
+DST="/mnt/music"
+LOG="/tmp/rsyncmusiclog.txt"
+
+# check that DST is the mounted disk image, not the mountpoint directory
+if ! findmnt --mountpoint $DST > /dev/null
+then
+  log "$DST not mounted, skipping music sync"
+  exit
+fi
+
+function connectionmonitor {
+  while true
+  do
+    for _ in {1..10}
+    do
+      if timeout 3 /root/bin/archive-is-reachable.sh "$ARCHIVE_SERVER"
+      then
+        # sleep and then continue outer loop
+        sleep 5
+        continue 2
+      fi
+      sleep 1
+    done
+    log "connection dead, killing copy-music"
+    # Give rsync a chance to clean up before killing it hard.
+    killall rsync || true
+    sleep 2
+    killall -9 rsync || true
+    kill -9 "$1" || true
+    return
+  done
+}
+
+function do_music_sync {
+  log "Syncing music from archive..."
+
+  # return immediately if the archive mount can't be accessed
+  if ! timeout 5 stat "$SRC" > /dev/null
+  then
+    log "Error: $SRC is not accessible"
+    return
+  fi
+
+  # check that SRC is the mounted nfs archive and not the empty mountpoint
+  # directory, since the latter would cause all music to be deleted from DST
+  if ! findmnt --mountpoint $SRC > /dev/null
+  then
+    log "Error: $SRC not mounted"
+    return
+  fi
+
+  connectionmonitor $$ &
+
+  if ! rsync -rum --no-human-readable --exclude=.fseventsd/*** --exclude=*.DS_Store --exclude=.metadata_never_index \
+                --exclude="System Volume Information/***" \
+                --delete --modify-window=2 --info=stats2 "$SRC/" "$DST" &> "$LOG"
+  then
+    log "rsync failed with error $?"
+  fi
+
+  # Stop the connection monitor.
+  kill %1 || true
+
+  # remove empty directories
+  find $DST -depth -type d -empty -delete || true
+
+  # parse log for relevant info
+  declare -i NUM_FILES_COPIED
+  NUM_FILES_COPIED=$(($(sed -n -e 's/\(^Number of regular files transferred: \)\([[:digit:]]\+\).*/\2/p' "$LOG")))
+  declare -i NUM_FILES_DELETED
+  NUM_FILES_DELETED=$(($(sed -n -e 's/\(^Number of deleted files: [[:digit:]]\+ (reg: \)\([[:digit:]]\+\)*.*/\2/p' "$LOG")))
+  declare -i TOTAL_FILES
+  TOTAL_FILES=$(sed -n -e 's/\(^Number of files: [[:digit:]]\+ (reg: \)\([[:digit:]]\+\)*.*/\2/p' "$LOG")
+  declare -i NUM_FILES_ERROR
+  NUM_FILES_ERROR=$(($(grep -c "failed to open" $LOG || true)))
+
+  declare -i NUM_FILES_SKIPPED=$((TOTAL_FILES-NUM_FILES_COPIED))
+  NUM_FILES_COPIED=$((NUM_FILES_COPIED-NUM_FILES_ERROR))
+
+  local message="Copied $NUM_FILES_COPIED music file(s), deleted $NUM_FILES_DELETED, skipped $NUM_FILES_SKIPPED previously-copied files, and encountered $NUM_FILES_ERROR errors."
+
+  if [ $NUM_FILES_COPIED -ne 0 ] || [ $NUM_FILES_DELETED -ne 0 ] || [ $NUM_FILES_ERROR -ne 0 ]
+  then
+    /root/bin/send-push-message "$NOTIFICATION_TITLE:" "$message" "" music_sync
+  else
+    log "$message"
+  fi
+}
+
+if ! do_music_sync
+then
+  log "Error while syncing music"
+fi

--- a/server/api/setup.go
+++ b/server/api/setup.go
@@ -308,7 +308,8 @@ func (h *handlers) testArchive(w http.ResponseWriter, r *http.Request) {
 		defer os.Remove(tmpDir)
 
 		src := fmt.Sprintf("%s:%s", server, exportPath)
-		_, testErr = shell.RunWithTimeout(timeout, "mount", "-t", "nfs", src, tmpDir, "-o", "nolock,soft,timeo=50")
+		// vers=3 to match fstab/legacy script; v4 fails on NAS exports with deep real paths (UniFi UNAS).
+		_, testErr = shell.RunWithTimeout(timeout, "mount", "-t", "nfs", src, tmpDir, "-o", "nolock,soft,timeo=50,vers=3,proto=tcp")
 		if testErr == nil {
 			shell.RunWithTimeout(5*time.Second, "umount", tmpDir)
 		}


### PR DESCRIPTION
## Summary

Three independent bugs that together prevent **NFS as an archive backend from working out of the box**. On a fresh install, the user can: pass the wizard's archive test (commit 1+2), get fstab written correctly during setup, mount the share, archive cam clips — but **music sync silently never runs** (commit 3). All three issues hit on the same UniFi UNAS / Synology-style NAS configuration.

### 1. `install.sh` — install `nfs-common` and `cifs-utils`

Without `nfs-common`, `/sbin/mount.nfs` doesn't exist. The Go server's archive-test endpoint runs `mount -t nfs ...`, util-linux uses the new `fsconfig()` API directly with no helper, and the kernel rejects the mount with:

```
mount: ...: fsconfig() failed: NFS: mount program didn't pass remote address.
```

The legacy `run/nfs_archive/verify-and-configure-archive.sh` already lazy-installs `nfs-common`, but only after the wizard's Test button has already failed. This change installs both archive helpers up-front.

### 2. `server/api/setup.go` — force `vers=3,proto=tcp` in the test mount

The test endpoint omitted `vers=`, so `mount.nfs` negotiated NFSv4. On NAS servers (UniFi UNAS, Synology) where the export's real path is deeply nested under a non-pseudo-root path (e.g. `/volume/<uuid>/.srv/.unifi-drive/<share>/.data`), v4 then fails with:

```
mount: ... NFS4: Couldn't follow remote path
```

Forcing v3 matches what `verify-and-configure-archive.sh` and the fstab entry written by `configure_archive` already do — the inline comment in the legacy script even calls out "Forced vers=3 for wider NAS compatibility (Unifi, Synology, etc)".

### 3. `run/nfs_archive/copy-music.sh` — replace recursive wrapper with actual rsync logic

The file was a 5-line wrapper that called `/root/bin/copy-music.sh` (i.e. itself once installed) and referenced `ensure_music_file_is_mounted` / `unmount_music_file` / `trim_free_space`. Those functions are defined inside `archiveloop` but not in its `export -f` block (`archiveloop:1230-1233`), so they're invisible from the subshell. Result, on every NFS archive cycle:

```
/root/bin/copy-music.sh: line 3: ensure_music_file_is_mounted: command not found
```

`archiveloop` already wraps the call in `ensure_music_file_is_mounted` → `/root/bin/copy-music.sh` → `trim_free_space` → `unmount_music_file` (`archiveloop:984-995`), so the wrapper's outer steps were duplicates anyway. CIFS and rsync archive variants ship a self-contained `copy-music.sh` with the actual rsync; only the NFS variant was a stub.

This commit makes the NFS variant self-contained, identical to the CIFS variant except for one comment ("nfs" vs "cifs" archive) — both source from `/mnt/musicarchive`.

## Reproduction

Reproduced on a fresh Pi image (Sentry-USB main-dev), Raspberry Pi 5, mounting a UniFi UNAS Pro export at `192.168.103.250` from a SentryUSB at `192.168.103.176`:

| Scenario | Result |
| --- | --- |
| Fresh install, `/api/setup/test-archive` (NFS) | `fsconfig() failed: NFS: mount program didn't pass remote address` |
| `nfs-common` installed, no `vers=3` | `NFS4: Couldn't follow remote path` |
| `nfs-common` installed + `vers=3,proto=tcp` (this PR) | `{"success":true}` |
| Setup completes, archive cycle runs | Cam clips archived; music sync logs `command not found: ensure_music_file_is_mounted` |
| `copy-music.sh` replaced with self-contained rsync (this PR) | `command not found` gone; rsync logic now executes |

Test endpoint verified via the same call the UI makes:

```bash
curl -sS -X POST http://sentryusb.local/api/setup/test-archive \
  -H 'Content-Type: application/json' \
  -d '{"ARCHIVE_SYSTEM":"nfs","ARCHIVE_SERVER":"192.168.103.250","SHARE_NAME":"/volume/<uuid>/.srv/.unifi-drive/TeslaCam/.data"}'
```

Music-sync runtime fix verified by hot-replacing `/root/bin/copy-music.sh` on a live install with the corrected logic; pre-fix logs showed the `command not found` error on every cycle, post-fix the script's stat/findmnt checks succeed and rsync is invoked. Initial sync end-to-end pending next archive cycle (gated on car reachability) — the fix is bytewise identical to the CIFS variant which is in production use.

## Test plan

- [ ] `cd server && make build-arm64` — I don't have a Go toolchain locally; the only Go change is a string-literal in an existing variadic `shell.RunWithTimeout` call, type-compatible by construction.
- [ ] Run `install.sh` on a fresh image, confirm `nfs-common` + `cifs-utils` get installed.
- [ ] In the setup wizard, configure NFS pointing at a UniFi UNAS export, click Test → expect success.
- [ ] Complete setup with a music drive + share configured, let one archive cycle run, confirm `/tmp/rsyncmusiclog.txt` has `Number of regular files transferred: N` and `du /mnt/music` grows.
- [ ] Repeat with a Synology / generic NFS server to confirm no regression for setups that already worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)