### PR TITLE
ui: bump text-slate-700 to text-slate-500 for WCAG AA contrast

### DIFF
--- a/web/src/components/setup/SetupWizard.tsx
+++ b/web/src/components/setup/SetupWizard.tsx
@@ -647,7 +647,7 @@ export function SetupWizard({ initialData, onClose }: SetupWizardProps) {
                 <p
                   className={cn(
                     "mt-1 hidden text-[10px] font-medium sm:block",
-                    i <= currentStep ? "text-slate-400" : "text-slate-700"
+                    i <= currentStep ? "text-slate-400" : "text-slate-500"
                   )}
                 >
                   {step.title}
@@ -681,7 +681,7 @@ export function SetupWizard({ initialData, onClose }: SetupWizardProps) {
               className={cn(
                 "flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors",
                 isFirst
-                  ? "text-slate-700"
+                  ? "text-slate-500"
                   : "text-slate-400 hover:bg-white/5 hover:text-slate-200"
               )}
             >

--- a/web/src/components/setup/steps/NotificationsStep.tsx
+++ b/web/src/components/setup/steps/NotificationsStep.tsx
@@ -165,7 +165,7 @@ function ProviderCard({ provider, data, onChange, errorFields }: { provider: Not
                     className={inputCls}
                   />
                 )}
-                {f.hint && <p className="mt-0.5 text-xs text-slate-700">{f.hint}</p>}
+                {f.hint && <p className="mt-0.5 text-xs text-slate-500">{f.hint}</p>}
               </div>
             )
           })}

--- a/web/src/pages/Files.tsx
+++ b/web/src/pages/Files.tsx
@@ -548,12 +548,12 @@ export default function Files() {
             </div>
           ) : error ? (
             <div className="flex flex-col items-center justify-center p-8">
-              <FolderOpen className="mb-2 h-10 w-10 text-slate-700" />
+              <FolderOpen className="mb-2 h-10 w-10 text-slate-500" />
               <p className="text-sm text-slate-500">{error}</p>
             </div>
           ) : sortedFiles.length === 0 ? (
             <div className="flex flex-col items-center justify-center p-8">
-              {(() => { const Icon = TAB_ICONS[activeDrive.icon]; return <Icon className="mb-2 h-10 w-10 text-slate-700" /> })()}
+              {(() => { const Icon = TAB_ICONS[activeDrive.icon]; return <Icon className="mb-2 h-10 w-10 text-slate-500" /> })()}
               <p className="text-sm text-slate-500">{search ? "No matching files" : "Empty folder"}</p>
               <p className="mt-1 text-xs text-slate-600">
                 {search ? "Try a different search term" : activeDrive.icon === "cam" ? "No clips in this folder" : "Upload files to get started"}

--- a/web/src/pages/LockChime.tsx
+++ b/web/src/pages/LockChime.tsx
@@ -614,7 +614,7 @@ function MyLibraryTab({ volume }: { volume: number }) {
 
         {!loading && sounds.length === 0 && (
           <div className="flex flex-col items-center gap-3 rounded-xl border border-white/10 bg-white/[0.02] py-12 text-center">
-            <Music className="h-10 w-10 text-slate-700" />
+            <Music className="h-10 w-10 text-slate-500" />
             <div>
               <p className="text-sm font-medium text-slate-400">No sounds yet</p>
               <p className="mt-1 text-xs text-slate-600">Upload a .wav file or download from the Community tab</p>
@@ -1470,14 +1470,14 @@ function CommunityBrowse({ adminPasscode, volume }: { adminPasscode: string | nu
 
       {!loading && error && (
         <div className="flex flex-col items-center gap-3 rounded-xl border border-white/10 bg-white/[0.02] py-16 text-center">
-          <Music className="h-10 w-10 text-slate-700" />
+          <Music className="h-10 w-10 text-slate-500" />
           <p className="text-sm text-slate-400">{error}</p>
         </div>
       )}
 
       {!loading && !error && sounds.length === 0 && (
         <div className="flex flex-col items-center gap-3 rounded-xl border border-white/10 bg-white/[0.02] py-16 text-center">
-          <Music className="h-10 w-10 text-slate-700" />
+          <Music className="h-10 w-10 text-slate-500" />
           <div>
             <p className="text-sm font-medium text-slate-400">No community sounds yet</p>
             <p className="mt-1 text-xs text-slate-600">Be the first to share a lock chime!</p>

--- a/web/src/pages/Support.tsx
+++ b/web/src/pages/Support.tsx
@@ -511,9 +511,9 @@ export default function Support() {
                   {status.text}
                 </span>
               ) : (
-                <span className="text-[10px] text-slate-700">Shift+Enter for newline</span>
+                <span className="text-[10px] text-slate-500">Shift+Enter for newline</span>
               )}
-              <span className="text-[10px] text-slate-700">{message.length}/5000</span>
+              <span className="text-[10px] text-slate-500">{message.length}/5000</span>
             </div>
           </div>
         )}

--- a/web/src/pages/Viewer.tsx
+++ b/web/src/pages/Viewer.tsx
@@ -668,7 +668,7 @@ export default function Viewer() {
                 })
               ) : (
                 <div className="flex flex-col items-center justify-center py-8 text-center">
-                  <Video className="mb-2 h-8 w-8 text-slate-700" />
+                  <Video className="mb-2 h-8 w-8 text-slate-500" />
                   <p className="text-xs text-slate-600">No {categoryLabels[activeCategory]?.toLowerCase()} clips</p>
                 </div>
               )}
@@ -781,7 +781,7 @@ export default function Viewer() {
                         </div>
                       ) : (
                         <div className="flex h-full items-center justify-center">
-                          <Video className="h-6 w-6 text-slate-700" />
+                          <Video className="h-6 w-6 text-slate-500" />
                         </div>
                       )}
                       {/* Camera label */}
@@ -940,7 +940,7 @@ export default function Viewer() {
           ) : (
             <div className="glass-card flex flex-1 items-center justify-center">
               <div className="max-w-xs text-center">
-                <Video className="mx-auto mb-3 h-16 w-16 text-slate-700" />
+                <Video className="mx-auto mb-3 h-16 w-16 text-slate-500" />
                 <p className="text-sm font-medium text-slate-400">
                   {selectedClip ? "No video files found" : "Select a clip to begin playback"}
                 </p>


### PR DESCRIPTION
First small PR from issue #52 (color contrast audit). Context: I've been helping test the NFS archive path (PR #51) and while sitting in the UI a few muted text tokens stood out as hard to read on the dark surfaces. The audit is in #52 — this PR is just the highest-impact single swap.

## What this changes

Replaces every `text-slate-700` (#334155) with `text-slate-500` (#64748b) across `web/src`. 13 lines across 6 files.

## Why

`text-slate-700` on the dark surfaces measures **1.4–2.0 : 1** contrast — well below WCAG 2.2 AA Normal (4.5 : 1), AA Large (3 : 1), and the SC 1.4.11 graphic-object rule (3 : 1) for the empty-state icons. After the swap each spot is at **~4.2 : 1**: passes AA Large and the 3:1 graphic-object rule, and visually preserves the "less prominent than body text" hierarchy. No design-language change, no token additions.

## Affected spots

- Setup wizard inactive step indicators
- `NotificationsStep` form-field hints
- Support page Shift+Enter / character counters
- Empty-state icons in Files, LockChime, Viewer

## Test plan

- [ ] Visual diff in dev: setup wizard steps, NotificationsStep hints, an empty Files folder, an empty LockChime library, an empty Viewer state
- [ ] Confirm muted text is still visually subordinate to body text (`text-slate-100/200/300`) — it should be; slate-500 sits between secondary (slate-400) and the formerly-invisible 700
- [ ] No regressions in light/active states (those already use slate-400)

Issue #52 lists the remaining lower-impact items (`text-slate-600`, `.section-label`, `.tab-item` alpha values, leaflet attribution) — happy to follow up in a separate PR if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)